### PR TITLE
fix: Apply local changes to in lowell-core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
- "lowell-core 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lowell-core",
  "serde",
  "serde_json",
  "tracing",
@@ -286,20 +286,6 @@ dependencies = [
  "serde",
  "sha2",
  "tempfile",
- "tracing",
-]
-
-[[package]]
-name = "lowell-core"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a84fc13574332db7c1287819bf9b2f0b98c4d1f1e67467a95589116dd839a34"
-dependencies = [
- "anyhow",
- "goblin",
- "rs-release",
- "serde",
- "sha2",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["lowell-cli", "lowell-core"]
 resolver = "2"
+
+# Local dev override: use the path crate instead of crates.io
+[patch.crates-io]
+lowell-core = { path = "lowell-core" }


### PR DESCRIPTION
Without this change, lowell-cli still references the cargo.io crate
instead of your local changes. Shouldn't affect the cargo publish process.

Signed-off-by: Sam Dasilva <samuelramos852@gmail.com>
