### PR TITLE
refactor: Swap inspect and uki modules hierarchy

### DIFF
--- a/lowell-cli/src/cli/mod.rs
+++ b/lowell-cli/src/cli/mod.rs
@@ -2,6 +2,8 @@
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
+mod uki;
+
 #[derive(Parser, Debug)]
 #[command(name = "lowell", version, about = "Hermetic initramfs/UKI builder")]
 pub struct Cli {
@@ -17,7 +19,7 @@ impl Cli {
     }
     pub fn run(self) -> Result<()> {
         match self.cmd {
-            Cmd::Inspect(a) => a.run(),
+            Cmd::Uki(a) => a.run(),
         }
     }
 }
@@ -31,7 +33,7 @@ pub struct GlobalArgs {
 
 #[derive(Subcommand, Debug)]
 enum Cmd {
-    Inspect(inspect::InspectArgs),
+    Uki(uki::UkiArgs),
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -54,8 +56,6 @@ impl LogLevel {
         }
     }
 }
-
-mod inspect;
 
 #[cfg(test)]
 mod tests {

--- a/lowell-cli/src/cli/uki/inspect.rs
+++ b/lowell-cli/src/cli/uki/inspect.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use anyhow::Result;
 use clap::{Args, ValueEnum};
-use lowell_core::inspect::uki::{self, Report, UkiOptions};
+use lowell_core::uki::inspect::{self, InspectOptions, Report};
 use std::io::{self, Write};
 use std::path::PathBuf;
 
@@ -13,9 +13,8 @@ enum Output {
 }
 
 #[derive(Args, Debug)]
-pub struct UkiArgs {
+pub struct InspectArgs {
     /// Path to the UKI to inspect
-    #[arg(long)]
     file: PathBuf,
     /// Output format (human by default)
     #[arg(long, value_enum, default_value_t = Output::Human)]
@@ -25,9 +24,9 @@ pub struct UkiArgs {
     verbose: bool,
 }
 
-impl UkiArgs {
+impl InspectArgs {
     pub fn run(self) -> Result<()> {
-        let report = uki::inspect(UkiOptions { file: self.file })?;
+        let report = inspect::inspect(InspectOptions { file: self.file })?;
         match self.format {
             Output::Human => print_human(&report, self.verbose)?,
             Output::Json => {

--- a/lowell-cli/src/cli/uki/mod.rs
+++ b/lowell-cli/src/cli/uki/mod.rs
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-mod uki;
+mod inspect;
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
 
 #[derive(Args, Debug)]
-pub struct InspectArgs {
+pub struct UkiArgs {
     #[command(subcommand)]
-    cmd: InspectCmd,
+    cmd: UkiCmd,
 }
 
 #[derive(Subcommand, Debug)]
-enum InspectCmd {
-    /// Uki contents from a UKI
-    Uki(uki::UkiArgs),
+enum UkiCmd {
+    /// Inspect contents from a UKI
+    Inspect(inspect::InspectArgs),
 }
 
-impl InspectArgs {
+impl UkiArgs {
     pub fn run(self) -> Result<()> {
         match self.cmd {
-            InspectCmd::Uki(a) => a.run(),
+            UkiCmd::Inspect(a) => a.run(),
         }
     }
 }

--- a/lowell-core/src/lib.rs
+++ b/lowell-core/src/lib.rs
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pub mod formats;
-pub mod inspect;
+pub mod uki;

--- a/lowell-core/src/uki/ext.rs
+++ b/lowell-core/src/uki/ext.rs
@@ -6,7 +6,7 @@
 //! bytes and file-location in one call.
 
 use crate::formats::pe::PeFile;
-use crate::inspect::uki::SectionInfo;
+use crate::uki::inspect::SectionInfo;
 use anyhow::Result; // adjust path if you moved SectionInfo
 
 // ---- Sealed extension trait (prevents external impls) ----

--- a/lowell-core/src/uki/inspect.rs
+++ b/lowell-core/src/uki/inspect.rs
@@ -2,7 +2,7 @@
 use crate::formats::initramfs::{detect, Compression};
 use crate::formats::osrel::{read_os_release, OsRelease};
 use crate::formats::pe::PeFile;
-use crate::inspect::ext::SectionLookupExt;
+use crate::uki::ext::SectionLookupExt;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
@@ -10,7 +10,7 @@ use std::time::Instant;
 use tracing::{debug, debug_span};
 
 #[derive(Debug)]
-pub struct UkiOptions {
+pub struct InspectOptions {
     /// Path to the UKI to inspect
     pub file: PathBuf,
 }
@@ -43,7 +43,7 @@ pub struct InitrdInfo {
     pub entries_estimate: Option<usize>,
 }
 
-pub fn inspect(UkiOptions { file: uki }: UkiOptions) -> Result<Report> {
+pub fn inspect(InspectOptions { file: uki }: InspectOptions) -> Result<Report> {
     // Parent span
     let _inspect_span = debug_span!("inspect", path = %uki.display()).entered();
 
@@ -211,7 +211,7 @@ VERSION_ID="1.2.3"
     #[ignore = "requires UKI_PATH"]
     fn inspect_real_uki_smoke() {
         let uki_path = std::env::var("UKI_PATH").expect("set UKI_PATH to a real UKI");
-        let report = inspect(UkiOptions {
+        let report = inspect(InspectOptions {
             file: uki_path.into(),
         })
         .expect("inspect report");

--- a/lowell-core/src/uki/mod.rs
+++ b/lowell-core/src/uki/mod.rs
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pub mod ext;
-pub mod uki;
+pub mod inspect;


### PR DESCRIPTION
Since we can still afford changing the api, we should use the noun-first command conventions for the tool as it scales better with time.